### PR TITLE
Feature/get tag method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/devops-cyberlab/hivebox
+
+go 1.24.3

--- a/hivecode/git-handler/tagging/readme.md
+++ b/hivecode/git-handler/tagging/readme.md
@@ -1,0 +1,4 @@
+## How to tag
+git tag v0.0.1-feature
+
+git push origin v0.0.1-feature

--- a/hivecode/git-handler/tagging/tag.go
+++ b/hivecode/git-handler/tagging/tag.go
@@ -1,0 +1,27 @@
+// File: git-handler/tagging/tag.go
+package tagging
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GetCurrentGitTag returns the latest Git tag or commit hash
+func GetCurrentGitTag() (string, error) {
+	// Try to get the latest tag
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	output, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	// Fallback: Get short commit hash
+	cmd = exec.Command("git", "rev-parse", "--short", "HEAD")
+	output, err = cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	return "", fmt.Errorf("failed to get Git version")
+}

--- a/hivecode/main.go
+++ b/hivecode/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/devops-cyberlab/hivebox/hivecode/git-handler/tagging"
+)
+
+func main() {
+	version, err := tagging.GetCurrentGitTag()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	fmt.Println("Git Version:", version)
+}


### PR DESCRIPTION
Method in go to retrieve current project tag version.
Simple readme with the commands to tag a git version.